### PR TITLE
Add helm schema

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,14 @@ RUN git clone https://github.com/norwoodj/helm-docs -b v1.11.0 \
     && go build ./cmd/helm-docs \
     && cp helm-docs /go/bin/helm-docs
 
+RUN git clone https://github.com/dadav/helm-schema -b 0.9.0 \
+    && cd helm-schema \
+    && go build ./cmd/helm-schema \
+    && cp helm-schema /go/bin/helm-schema
+
 RUN chmod +x /go/bin/helm
 RUN chmod +x /go/bin/helm-docs
+RUN chmod +x /go/bin/helm-schema
 
 FROM --platform=${BUILDPLATFORM} python:${PY_VERSION}-bullseye as pybuilder
 # TARGETARCH is an automatic platform ARG enabled by Docker BuildKit.
@@ -52,6 +58,7 @@ ARG PY_MINOR=3.9
 
 COPY --from=gobuilder /go/bin/helm /usr/bin/helm
 COPY --from=gobuilder /go/bin/helm-docs /usr/bin/helm-docs
+COPY --from=gobuilder /go/bin/helm-schema /usr/bin/helm-schema
 COPY --from=pybuilder /usr/local/lib/python${PY_MINOR}/site-packages /usr/local/lib/python${PY_MINOR}/dist-packages/
 COPY --from=pybuilder /usr/local/bin/m2r2 /usr/bin/m2r2
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GO_VERSION=1.19.5
+ARG GO_VERSION=1.21.7
 ARG PY_VERSION=3.9.13
 
 FROM --platform=${BUILDPLATFORM} golang:${GO_VERSION}-bullseye as gobuilder

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ markdown content. Includes:
 
 * [helm](https://github.com/helm/helm)
 * [helm-docs](https://github.com/norwoodj/helm-docs)
+* [helm-schema](https://github.com/dadav/helm-schema)
 * [m2r2](https://github.com/CrossNox/m2r2)
 
 ## Building the image
@@ -21,6 +22,7 @@ $ docker buildx build --platform ${PLATFORMS} . -t quay.io/cilium/helm-toolbox:$
 ```
 $ docker container run THIS-IMAGE helm ...
 $ docker container run --rm --workdir /src/install/kubernetes --volume /path/to/cilium/:/src --user "1001:1001" THIS-IMAGE /usr/bin/helm-docs ...
+$ docker container run --rm --workdir /src/install/kubernetes --volume /path/to/cilium/:/src --user "1001:1001" THIS-IMAGE /usr/bin/helm-schema -c /src/install/kubernetes ...
 $ docker container run THIS-IMAGE python3 /usr/bin/m2r2 ...
 ```
 


### PR DESCRIPTION
This PR is a requirement for https://github.com/cilium/cilium/pull/30631

Changes

- Update golang to 1.21.7 (required for building `helm-schema`)
- Install [`dadav/helm-schema`](https://github.com/dadav/helm-schema)

I've pushed the container image to `quay.io/geraldpape/helm-toolbox:v1.1.0` to work with it in the other PR